### PR TITLE
feat: refresh storefront UI with shadcn-inspired components

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,19 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  body {
+    background-color: #f8fafc;
+    color: #0f172a;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    background-image: radial-gradient(
+        rgba(56, 189, 248, 0.18) 1px,
+        transparent 0
+      ),
+      radial-gradient(rgba(96, 165, 250, 0.12) 1px, transparent 0);
+    background-position: 0 0, 25px 25px;
+    background-size: 50px 50px;
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,9 @@
 import type { Metadata } from "next";
+import { Inter } from "next/font/google";
+
 import "./globals.css";
+
+const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
 
 export const metadata: Metadata = {
   title: "Digital Downloads Store",
@@ -13,7 +17,14 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body className={inter.className}>
+        <div className="relative flex min-h-screen flex-col">
+          <div className="pointer-events-none absolute inset-0 -z-10 opacity-80 [mask-image:radial-gradient(circle_at_center,black,transparent)]">
+            <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_20%,rgba(56,189,248,0.25),transparent_50%),radial-gradient(circle_at_80%_10%,rgba(147,197,253,0.25),transparent_55%),radial-gradient(circle_at_20%_80%,rgba(96,165,250,0.2),transparent_45%)]" />
+          </div>
+          {children}
+        </div>
+      </body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,21 +1,175 @@
-import { products } from "@/lib/products";
+import Link from "next/link";
+
 import ProductCard from "@/components/ProductCard";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
+import {
+  ArrowRightIcon,
+  MonitorSmartphoneIcon,
+  PaletteIcon,
+  ShieldCheckIcon,
+  SparklesIcon,
+  TimerResetIcon,
+} from "@/components/ui/icons";
+import { products } from "@/lib/products";
+
+const features = [
+  {
+    title: "Crafted by experts",
+    description:
+      "Every resource is built by seasoned creators who ship production-ready experiences.",
+    icon: SparklesIcon,
+  },
+  {
+    title: "Polished design systems",
+    description:
+      "Crisp typography, responsive layouts, and accessible components that feel premium.",
+    icon: PaletteIcon,
+  },
+  {
+    title: "Lifetime updates",
+    description:
+      "Download once and receive updates as we add modules, chapters, and new assets.",
+    icon: TimerResetIcon,
+  },
+];
+
+const trustSignals = [
+  {
+    title: "Secure checkout",
+    description: "Encrypted Stripe payments with instant download links.",
+    icon: ShieldCheckIcon,
+  },
+  {
+    title: "Multi-format files",
+    description: "Compatible with your favorite tools including Figma and VS Code.",
+    icon: MonitorSmartphoneIcon,
+  },
+];
 
 export default function Home() {
   return (
-    <main className="min-h-screen bg-gray-50 py-12 px-4">
-      <div className="max-w-7xl mx-auto">
-        <h1 className="text-4xl font-bold text-center mb-4">Digital Downloads Store</h1>
-        <p className="text-gray-600 text-center mb-12">
-          Purchase premium digital products instantly
-        </p>
+    <main className="relative pb-24 pt-20">
+      <section className="container relative z-10 flex flex-col gap-10 text-center">
+        <div className="mx-auto max-w-xl">
+          <Badge className="mb-6 w-fit">
+            Launch collection
+          </Badge>
+          <h1 className="text-balance text-4xl font-semibold tracking-tight text-slate-900 md:text-5xl lg:text-6xl">
+            Digital products you can launch this weekend
+          </h1>
+          <p className="mt-6 text-lg text-slate-600">
+            Level up your content creation with courses, UI kits, and guides curated for modern makers. Download instantly and start building without the guesswork.
+          </p>
+        </div>
+        <div className="flex flex-col items-center justify-center gap-3 sm:flex-row">
+          <Button className="px-8 text-base">Browse the collection</Button>
+          <Link
+            href="#products"
+            className="inline-flex h-11 items-center justify-center rounded-md border border-slate-200 bg-white px-8 text-base font-medium text-slate-900 transition-colors hover:bg-slate-100"
+          >
+            View products <ArrowRightIcon className="ml-2 h-4 w-4" />
+          </Link>
+        </div>
+        <div className="grid gap-6 md:grid-cols-3">
+          {features.map(({ title, description, icon: Icon }) => (
+            <Card
+              key={title}
+              className="border-none bg-white/80 p-6 shadow-lg ring-1 ring-slate-200/60 backdrop-blur supports-[backdrop-filter]:bg-white/60"
+            >
+              <CardHeader className="space-y-4 p-0">
+                <span className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-sky-100 text-sky-600">
+                  <Icon className="h-5 w-5" />
+                </span>
+                <CardTitle className="text-left text-xl font-semibold">
+                  {title}
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="p-0 pt-3 text-left text-sm text-slate-600">
+                {description}
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </section>
 
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+      <section
+        id="products"
+        className="container relative z-10 mt-20 flex flex-col gap-12"
+      >
+        <div className="mx-auto max-w-2xl text-center">
+          <h2 className="text-3xl font-semibold tracking-tight md:text-4xl">
+            Curated downloads for modern creators
+          </h2>
+          <p className="mt-4 text-slate-600">
+            Choose a resource crafted to accelerate your workflow. Every download is ready to use with zero friction.
+          </p>
+        </div>
+
+        <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
           {products.map((product) => (
             <ProductCard key={product.id} product={product} />
           ))}
         </div>
-      </div>
+      </section>
+
+      <section className="container relative z-10 mt-24 grid gap-8 lg:grid-cols-[1.15fr_0.85fr]">
+        <Card className="border-none bg-white/90 p-8 shadow-xl ring-1 ring-slate-200/60 backdrop-blur supports-[backdrop-filter]:bg-white/60">
+          <CardHeader className="space-y-3 p-0">
+            <CardTitle className="text-3xl font-semibold">
+              Stay in the loop
+            </CardTitle>
+            <p className="text-slate-600">
+              Sign up for product drops, launch discounts, and behind-the-scenes lessons. No spam—only actionable resources.
+            </p>
+          </CardHeader>
+          <CardContent className="p-0 pt-6">
+            <form className="flex flex-col gap-3 sm:flex-row">
+              <Input placeholder="you@example.com" type="email" required />
+              <Button type="submit" className="w-full sm:w-auto">
+                Join waitlist
+              </Button>
+            </form>
+            <p className="mt-3 text-xs text-slate-500">
+              We respect your inbox. Unsubscribe anytime.
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card className="border-none bg-slate-100/70 p-8 shadow-lg ring-1 ring-slate-200/60 backdrop-blur supports-[backdrop-filter]:bg-slate-100/40">
+          <CardHeader className="space-y-3 p-0">
+            <CardTitle className="text-2xl font-semibold">
+              Why creators trust us
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-6 p-0">
+            {trustSignals.map(({ title, description, icon: Icon }) => (
+              <div
+                key={title}
+                className="flex items-start gap-4 rounded-xl border border-slate-200 bg-white/70 p-4"
+              >
+                <span className="mt-1 flex h-10 w-10 items-center justify-center rounded-full bg-sky-100 text-sky-600">
+                  <Icon className="h-5 w-5" />
+                </span>
+                <div className="space-y-1">
+                  <p className="font-medium text-slate-900">{title}</p>
+                  <p className="text-sm text-slate-600">{description}</p>
+                </div>
+              </div>
+            ))}
+            <Separator className="bg-slate-200" />
+            <p className="text-sm text-slate-600">
+              "These downloads helped me ship a polished product in days, not weeks. The polish and attention to detail is unmatched."
+            </p>
+            <p className="text-sm font-semibold text-slate-900">
+              — Jordan, indie creator
+            </p>
+          </CardContent>
+        </Card>
+      </section>
     </main>
   );
 }

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -2,6 +2,19 @@
 
 import { Product } from "@/lib/products";
 
+import { Badge } from "./ui/badge";
+import { Button } from "./ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "./ui/card";
+import { Separator } from "./ui/separator";
+import { CheckIcon, DownloadCloudIcon, StarIcon } from "./ui/icons";
+
 interface ProductCardProps {
   product: Product;
 }
@@ -32,20 +45,70 @@ export default function ProductCard({ product }: ProductCardProps) {
   };
 
   return (
-    <div className="bg-white rounded-lg shadow-md p-6 flex flex-col">
-      <h2 className="text-2xl font-semibold mb-2">{product.title}</h2>
-      <p className="text-gray-600 mb-4 flex-grow">{product.description}</p>
-      <div className="mt-4">
-        <p className="text-3xl font-bold text-blue-600 mb-4">
-          ${(product.price / 100).toFixed(2)}
-        </p>
-        <button
-          onClick={handleBuyNow}
-          className="w-full bg-blue-600 text-white py-3 px-6 rounded-lg font-semibold hover:bg-blue-700 transition-colors"
-        >
-          Buy Now
-        </button>
-      </div>
-    </div>
+    <Card className="flex h-full flex-col overflow-hidden border border-slate-200 bg-gradient-to-b from-white via-slate-50 to-slate-100">
+      <CardHeader className="space-y-4">
+        <div className="flex items-center justify-between">
+          <Badge variant="outline" className="bg-slate-100 text-xs tracking-wide text-slate-600">
+            {product.category}
+          </Badge>
+          {product.popular ? (
+            <span className="inline-flex items-center gap-1 text-xs font-medium text-amber-500">
+              <StarIcon className="h-4 w-4 fill-amber-400 text-amber-400" /> Popular
+            </span>
+          ) : null}
+        </div>
+        <div>
+          <CardTitle className="text-2xl font-semibold text-slate-900">
+            {product.title}
+          </CardTitle>
+          <CardDescription className="mt-2 text-base leading-relaxed">
+            {product.description}
+          </CardDescription>
+        </div>
+      </CardHeader>
+      <CardContent className="flex flex-1 flex-col justify-between space-y-6">
+        <div className="space-y-4">
+          <div className="flex items-center justify-between rounded-xl border border-dashed border-slate-200 bg-slate-100 px-4 py-3 text-sm text-slate-600">
+            <span>{product.format}</span>
+            <span className="font-medium text-slate-900">{product.level}</span>
+          </div>
+          <Separator className="bg-slate-200" />
+          <ul className="space-y-3 text-sm text-slate-600">
+            {product.highlights.map((highlight) => (
+              <li key={highlight} className="flex items-start gap-3">
+                <span className="mt-0.5 rounded-full bg-sky-100 p-1">
+                  <CheckIcon className="h-3.5 w-3.5 text-sky-600" />
+                </span>
+                <span className="leading-snug">{highlight}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="rounded-2xl bg-gradient-to-r from-sky-100 via-sky-50 to-transparent p-4">
+          <p className="text-xs font-medium uppercase tracking-wide text-slate-500">
+            Instant access
+          </p>
+          <div className="mt-2 flex items-end justify-between">
+            <div>
+              <p className="text-3xl font-semibold text-slate-900">
+                ${(product.price / 100).toFixed(2)}
+              </p>
+              <p className="text-xs text-slate-500">One-time purchase</p>
+            </div>
+            <div className="flex items-center gap-1 text-xs text-slate-500">
+              <DownloadCloudIcon className="h-4 w-4 text-sky-600" /> Download immediately
+            </div>
+          </div>
+        </div>
+      </CardContent>
+      <CardFooter className="flex flex-col gap-3">
+        <Button className="w-full" onClick={handleBuyNow}>
+          Purchase &amp; Download
+        </Button>
+        <Button variant="outline" className="w-full border-dashed">
+          Preview sample
+        </Button>
+      </CardFooter>
+    </Card>
   );
 }

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -103,7 +103,7 @@ export default function ProductCard({ product }: ProductCardProps) {
       </CardContent>
       <CardFooter className="flex flex-col gap-3">
         <Button className="w-full" onClick={handleBuyNow}>
-          Purchase &amp; Download
+          Purchase & Download
         </Button>
         <Button variant="outline" className="w-full border-dashed">
           Preview sample

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,0 +1,22 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface BadgeProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant?: "default" | "secondary" | "outline";
+}
+
+export function Badge({ className, variant = "default", ...props }: BadgeProps) {
+  return (
+    <div
+      className={cn(
+        "inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium uppercase tracking-wide",
+        variant === "default" && "border-transparent bg-sky-100 text-sky-700",
+        variant === "secondary" && "border-transparent bg-slate-200 text-slate-900",
+        variant === "outline" && "border-sky-200 text-sky-600",
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const baseStyles =
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-white";
+
+const variantStyles = {
+  default: "bg-sky-500 text-white shadow hover:bg-sky-600 hover:shadow-glow",
+  secondary: "bg-slate-900 text-white hover:bg-slate-800",
+  outline: "border border-slate-200 bg-transparent text-slate-900 hover:bg-slate-100",
+  ghost: "text-slate-900 hover:bg-slate-100",
+  destructive: "bg-rose-500 text-white shadow-sm hover:bg-rose-600",
+  link: "text-sky-600 underline-offset-4 hover:underline",
+} as const;
+
+const sizeStyles = {
+  default: "h-11 px-6 py-2",
+  sm: "h-9 rounded-md px-4",
+  lg: "h-12 rounded-lg px-8 text-base",
+  icon: "h-10 w-10",
+} as const;
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: keyof typeof variantStyles;
+  size?: keyof typeof sizeStyles;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = "default", size = "default", ...props }, ref) => {
+    return (
+      <button
+        ref={ref}
+        className={cn(baseStyles, variantStyles[variant], sizeStyles[size], className)}
+        {...props}
+      />
+    );
+  }
+);
+Button.displayName = "Button";
+
+export { Button };

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -1,0 +1,71 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        "rounded-2xl border border-slate-200 bg-white text-slate-900 shadow-sm transition-all hover:border-slate-300 hover:shadow-lg",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Card.displayName = "Card";
+
+const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    {...props}
+  />
+));
+CardHeader.displayName = "CardHeader";
+
+const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h3
+    ref={ref}
+    className={cn("text-2xl font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+));
+CardTitle.displayName = "CardTitle";
+
+const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p
+    ref={ref}
+    className={cn("text-sm text-slate-600", className)}
+    {...props}
+  />
+));
+CardDescription.displayName = "CardDescription";
+
+const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+));
+CardContent.displayName = "CardContent";
+
+const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("flex items-center p-6 pt-0", className)} {...props} />
+));
+CardFooter.displayName = "CardFooter";
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/components/ui/icons.tsx
+++ b/components/ui/icons.tsx
@@ -1,0 +1,99 @@
+import * as React from "react";
+
+const strokeProps = {
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 1.5,
+  strokeLinecap: "round" as const,
+  strokeLinejoin: "round" as const,
+  width: 24,
+  height: 24,
+};
+
+export function ArrowRightIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" {...strokeProps} {...props}>
+      <path d="M5 12h14" />
+      <path d="m13 6 6 6-6 6" />
+    </svg>
+  );
+}
+
+export function SparklesIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" {...strokeProps} {...props}>
+      <path d="M12 3v4" />
+      <path d="M10 5h4" />
+      <path d="m9 13-2 7 5-3 5 3-2-7 5-3h-6L12 4l-2 6H4z" />
+    </svg>
+  );
+}
+
+export function PaletteIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" {...strokeProps} {...props}>
+      <path d="M12 3a9 9 0 0 0-9 9c0 4.45 3.08 7 6 7 .7 0 1.26-.56 1.26-1.26 0-.66-.48-1.13-.48-1.99 0-1.07 1.08-2.05 2.22-2.05h3.83c1.67 0 3.17-1.14 3.17-2.8A8 8 0 0 0 12 3Z" />
+      <path d="M7.5 10.5h.01" />
+      <path d="M10.5 7.5h.01" />
+      <path d="M13.5 10.5h.01" />
+      <path d="M16.5 7.5h.01" />
+    </svg>
+  );
+}
+
+export function TimerResetIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" {...strokeProps} {...props}>
+      <path d="M12 8v4l2.5 2.5" />
+      <path d="M21 12A9 9 0 1 1 3 12" />
+      <path d="M7 4V2" />
+      <path d="M17 4V2" />
+      <path d="M3 3l2.5 2.5L8 6" />
+    </svg>
+  );
+}
+
+export function ShieldCheckIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" {...strokeProps} {...props}>
+      <path d="M12 22c4.8-2 8-5.5 8-10V5l-8-3-8 3v7c0 4.5 3.2 8 8 10Z" />
+      <path d="m9 12 2 2 4-4" />
+    </svg>
+  );
+}
+
+export function MonitorSmartphoneIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" {...strokeProps} {...props}>
+      <rect x="2" y="3" width="15" height="14" rx="2" />
+      <path d="M17 8h1a2 2 0 0 1 2 2v8a3 3 0 0 1-3 3h-4" />
+      <path d="M9 18h6" />
+    </svg>
+  );
+}
+
+export function CheckIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" {...strokeProps} {...props}>
+      <path d="m5 12 5 5 9-9" />
+    </svg>
+  );
+}
+
+export function DownloadCloudIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" {...strokeProps} {...props}>
+      <path d="M20 16.58A5 5 0 0 0 18 7h-1.26A8 8 0 1 0 4 15" />
+      <path d="M12 12v9" />
+      <path d="m8 17 4 4 4-4" />
+    </svg>
+  );
+}
+
+export function StarIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" aria-hidden="true" {...strokeProps} {...props}>
+      <path d="M12 3.25 14.45 8l5.3.77-3.83 3.73.9 5.26L12 15.77 7.18 17.76l.9-5.26L4.25 8.77 9.55 8z" />
+    </svg>
+  );
+}

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-11 w-full rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm shadow-sm transition-colors placeholder:text-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-300 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Input.displayName = "Input";
+
+export { Input };

--- a/components/ui/separator.tsx
+++ b/components/ui/separator.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export interface SeparatorProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  orientation?: "horizontal" | "vertical";
+}
+
+export function Separator({
+  className,
+  orientation = "horizontal",
+  ...props
+}: SeparatorProps) {
+  return (
+    <div
+      className={cn(
+        "shrink-0 bg-slate-200",
+        orientation === "horizontal" ? "h-px w-full" : "h-full w-px",
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/lib/products.ts
+++ b/lib/products.ts
@@ -5,6 +5,11 @@ export interface Product {
   price: number;
   priceId: string; // Stripe Price ID
   downloadUrl: string;
+  category: string;
+  level: "Beginner" | "Intermediate" | "Advanced";
+  format: string;
+  highlights: string[];
+  popular?: boolean;
 }
 
 export const products: Product[] = [
@@ -15,6 +20,15 @@ export const products: Product[] = [
     price: 2999, // $29.99 in cents
     priceId: "price_test_ebook", // Replace with actual Stripe Price ID
     downloadUrl: "/downloads/web-dev-guide.pdf",
+    category: "Guides",
+    level: "Beginner",
+    format: "200-page PDF",
+    highlights: [
+      "Step-by-step curriculum",
+      "Project-based learning",
+      "Access to resource library",
+    ],
+    popular: true,
   },
   {
     id: "2",
@@ -23,6 +37,14 @@ export const products: Product[] = [
     price: 4999, // $49.99 in cents
     priceId: "price_test_uikit", // Replace with actual Stripe Price ID
     downloadUrl: "/downloads/ui-kit.zip",
+    category: "Design",
+    level: "Intermediate",
+    format: "Figma & Sketch files",
+    highlights: [
+      "30+ ready-made screens",
+      "Light & dark mode",
+      "Editable components",
+    ],
   },
   {
     id: "3",
@@ -31,5 +53,14 @@ export const products: Product[] = [
     price: 7999, // $79.99 in cents
     priceId: "price_test_course", // Replace with actual Stripe Price ID
     downloadUrl: "/downloads/typescript-course.zip",
+    category: "Courses",
+    level: "Advanced",
+    format: "10-hour video series",
+    highlights: [
+      "Hands-on projects",
+      "Expert code reviews",
+      "Lifetime updates",
+    ],
+    popular: true,
   },
 ];

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,38 @@
+type ClassValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | ClassValue[]
+  | { [key: string]: boolean | string | number | null | undefined };
+
+export function cn(...inputs: ClassValue[]): string {
+  const classes: string[] = [];
+
+  const process = (value: ClassValue): void => {
+    if (!value) return;
+
+    if (typeof value === "string" || typeof value === "number") {
+      classes.push(String(value));
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      value.forEach(process);
+      return;
+    }
+
+    if (typeof value === "object") {
+      Object.entries(value).forEach(([key, val]) => {
+        if (val) {
+          classes.push(key);
+        }
+      });
+    }
+  };
+
+  inputs.forEach(process);
+
+  return classes.join(" ");
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,13 +1,29 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
+  darkMode: ["class"],
   content: [
     "./pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
-    extend: {},
+    container: {
+      center: true,
+      padding: "2rem",
+      screens: {
+        "2xl": "1400px",
+      },
+    },
+    extend: {
+      backgroundImage: {
+        "grid-pattern":
+          "linear-gradient(90deg, rgba(255,255,255,0.08) 1px, transparent 1px), linear-gradient(0deg, rgba(255,255,255,0.08) 1px, transparent 1px)",
+      },
+      boxShadow: {
+        glow: "0 0 45px -10px rgba(56, 189, 248, 0.45)",
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- rebuild the homepage with a shadcn-inspired hero, feature highlights, product grid, and trust section for a more polished storefront
- introduce reusable UI primitives (button, badge, card, separator, input, icons) plus a small utility helper to style product cards and supporting sections
- enrich product metadata to surface categories, levels, and highlights while updating Tailwind settings and global styles to match the refreshed look

## Testing
- npm run dev
- npm run lint *(fails: prompts for interactive configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e16ef0373c83309361326f90df508b